### PR TITLE
added SourceRoot as a prefix to Source

### DIFF
--- a/src/SourceMapConsumer.cs
+++ b/src/SourceMapConsumer.cs
@@ -80,7 +80,7 @@ namespace SourceMapDotNet
                     .Where(x => x.SourceLineIndex.HasValue)
                     .Select(x => new SourceReference
                     {
-                        File = x.SourcesIndex.HasValue ? _file.Sources[x.SourcesIndex.Value] : _file.File,
+                        File = x.SourcesIndex.HasValue ? _file.SourceRoot+_file.Sources[x.SourcesIndex.Value] : _file.File,
                         LineNumber = x.SourceLineIndex.Value + 1
                     })
                     .Distinct(new SourceReferenceEqualityComparer())

--- a/tests/SourceMapConsumerTests.cs
+++ b/tests/SourceMapConsumerTests.cs
@@ -85,6 +85,16 @@ namespace SourceMapDotNetTests
         }
 
         [Test]
+        public void OriginalPositionsFor_ReturnsFilePathWhichRespectsSourceRoot()
+        {
+            // Line 1 maps to lines 2 and 11
+            var consumer = new SourceMapConsumer(new SourceMapFile { Version = 3, Sources = new[] { "File", "OriginalFile" }, SourceRoot="RootPath/" });
+            var sourceLines = consumer.OriginalPositionsFor(1);
+
+            Assert.That(sourceLines.All(x => x.File == "RootPath/OriginalFile"));
+        }
+
+        [Test]
         public void OriginalPositionsFor_ReturnsEmptyArray_IfNoMatchingSourceLines()
         {
             var consumer = new SourceMapConsumer(new SourceMapFile { Version = 3 });


### PR DESCRIPTION
Introduces Support for SourceMaps where the SourceRoot property is not empty
